### PR TITLE
Support marshmallow 4.0.0 & add e2e tests

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,1 +1,1 @@
-marshmallow>=3.12.0,<4
+marshmallow>=4.0.0

--- a/src/marshmallow_generic/__init__.py
+++ b/src/marshmallow_generic/__init__.py
@@ -51,7 +51,8 @@ from marshmallow.decorators import (  # `post_load` overloaded
 )
 from marshmallow.exceptions import ValidationError
 from marshmallow.schema import Schema, SchemaOpts
-from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, missing, pprint
+from marshmallow.constants import EXCLUDE, INCLUDE, RAISE, missing
+from pprint import pprint
 
 from marshmallow_generic.decorators import post_load
 from marshmallow_generic.schema import GenericSchema

--- a/src/marshmallow_generic/decorators.py
+++ b/src/marshmallow_generic/decorators.py
@@ -17,7 +17,7 @@ _P = ParamSpec("_P")
 @overload
 def post_load(
     fn: Callable[_P, _R],
-    pass_many: bool = False,
+    pass_collection: bool = False,
     pass_original: bool = False,
 ) -> Callable[_P, _R]:
     ...
@@ -26,7 +26,7 @@ def post_load(
 @overload
 def post_load(
     fn: None = None,
-    pass_many: bool = False,
+    pass_collection: bool = False,
     pass_original: bool = False,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     ...
@@ -34,7 +34,7 @@ def post_load(
 
 def post_load(
     fn: Optional[Callable[..., Any]] = None,
-    pass_many: bool = False,
+    pass_collection: bool = False,
     pass_original: bool = False,
 ) -> Callable[..., Any]:
     """
@@ -55,7 +55,7 @@ def post_load(
             The function to decorate or `None`; if a function is supplied,
             a decorated version of it is returned; if `None` the decorator
             is returned with its other arguments already bound.
-        pass_many:
+        pass_collection:
             If `True`, the raw data (which may be a collection) is passed
         pass_original:
             If `True`, the original data (before deserializing) will be passed
@@ -65,7 +65,7 @@ def post_load(
         (Callable[P, R]): if `fn` is passed a function
         (Callable[[Callable[P, R]], Callable[P, R]]): if `fn` is `None`
     """
-    return _post_load(fn, pass_many=pass_many, pass_original=pass_original)
+    return _post_load(fn, pass_collection=pass_collection, pass_original=pass_original)
 
 
 # Keeping the signature as close as possible to the original decorator.

--- a/src/marshmallow_generic/schema.py
+++ b/src/marshmallow_generic/schema.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union, overload
 from warnings import warn
 
-from marshmallow import Schema
+from marshmallow import Schema, types
 
 from ._util import GenericInsightMixin1
 from .decorators import post_load
@@ -52,14 +52,13 @@ class GenericSchema(GenericInsightMixin1[Model], Schema):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        only: Union[Sequence[str], set[str], None] = None,
-        exclude: Union[Sequence[str], set[str]] = (),
-        context: Union[dict[str, Any], None] = None,
-        load_only: Union[Sequence[str], set[str]] = (),
-        dump_only: Union[Sequence[str], set[str]] = (),
-        partial: Union[bool, Sequence[str], set[str]] = False,
-        unknown: Optional[str] = None,
-        many: bool = False,  # usage discouraged
+        only: types.StrSequenceOrSet | None = None,
+        exclude: types.StrSequenceOrSet = (),
+        many: bool | None = None,
+        load_only: types.StrSequenceOrSet = (),
+        dump_only: types.StrSequenceOrSet = (),
+        partial: bool | types.StrSequenceOrSet | None = None,
+        unknown: types.UnknownOption | None = None,
     ) -> None:
         """
         Emits a warning, if the `many` argument is not `False`.
@@ -76,10 +75,6 @@ class GenericSchema(GenericInsightMixin1[Model], Schema):
                 the Schema. If a field appears in both `only` and `exclude`,
                 it is not used. Nested fields can be represented with dot
                 delimiters.
-            context:
-                Optional context passed to
-                [`Method`][marshmallow.fields.Method] and
-                [`Function`][marshmallow.fields.Function] fields.
             load_only:
                 Fields to skip during serialization (write-only fields)
             dump_only:
@@ -110,7 +105,6 @@ class GenericSchema(GenericInsightMixin1[Model], Schema):
             only=only,
             exclude=exclude,
             many=many,
-            context=context,
             load_only=load_only,
             dump_only=dump_only,
             partial=partial,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -13,16 +13,16 @@ class DecoratorsTestCase(TestCase):
         def test_function(x: int) -> str:
             return str(x)
 
-        pass_many, pass_original = MagicMock(), MagicMock()
+        pass_collection, pass_original = MagicMock(), MagicMock()
         # Explicit annotation to possibly catch mypy errors:
         output: Callable[[int], str] = decorators.post_load(
             test_function,
-            pass_many=pass_many,
+            pass_collection=pass_collection,
             pass_original=pass_original,
         )
         self.assertIs(expected_output, output)
         mock_original_post_load.assert_called_once_with(
             test_function,
-            pass_many=pass_many,
+            pass_collection=pass_collection,
             pass_original=pass_original,
         )

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from unittest import TestCase
+
+from marshmallow import fields
+from marshmallow_generic import GenericSchema
+
+@dataclass
+class Foo:
+    field1: int
+    field2: str
+
+class FooSchema(GenericSchema[Foo]):
+    field1 = fields.Integer()
+    field2 = fields.String()
+
+class TestEnd2End(TestCase):
+    def test_end2end_dump(self) -> None:
+        foo = Foo(field1=1, field2="test")
+        schema = FooSchema()
+        result = schema.dump(foo)
+
+        self.assertEqual(result, {"field1": 1, "field2": "test"})
+
+    def test_end2end_load(self) -> None:
+        schema = FooSchema()
+        result = schema.load({"field1": 1, "field2": "test"})
+
+        self.assertEqual(result, Foo(field1=1, field2="test"))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -14,7 +14,6 @@ class GenericSchemaTestCase(TestCase):
         kwargs: dict[str, Any] = {
             "only": object(),
             "exclude": object(),
-            "context": object(),
             "load_only": object(),
             "dump_only": object(),
             "partial": object(),


### PR DESCRIPTION
Hi! I saw your repo in the [StackOverflow answer](https://stackoverflow.com/a/76113256) and wanted to use it, but discovered that it no longer works since the update of `marshmallow` to version 4 (which introduced [a bunch of breaking changes](https://marshmallow.readthedocs.io/en/latest/upgrading.html#upgrading-to-4-0)) since it uses fields that were removed in the update. 

This PR addresses all the necessary changes and also adds some simple e2e tests, as none of the existing tests failed when the `marshmallow` dependency was upgraded in the `requirements.txt`.

Let me know if anything needs to be changed. 